### PR TITLE
Add version pins for react-native-meteor and react-navigation packages

### DIFF
--- a/TripRevisor/package.json
+++ b/TripRevisor/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "react": "15.4.2",
     "react-native": "0.42.3",
-    "react-native-meteor": "^1.0.3",
-    "react-navigation": "^1.0.0-beta.7"
+    "react-native-meteor": "1.0.3",
+    "react-navigation": "1.0.0-beta.7"
   },
   "devDependencies": {
     "babel-jest": "19.0.0",


### PR DESCRIPTION
Trying to run the project as-is gave me a couple of problems:

1. `npm WARN react-native-meteor@1.1.0 requires a peer of react-native@^0.46.0 but none was installed.`
2. The newer `react-navigation@1.0.0-beta.11` caused the iOS app to error before launch.

Replacing the `^version` pins with `version` pins allows me to launch the app without making any changes to the code. 

While we may end up refactoring this code in the future, this fix keeps the demo for this tutorial working. 